### PR TITLE
Remove CocoaPods support, require Swift Package Manager for iOS

### DIFF
--- a/ios/c2pa_flutter.podspec
+++ b/ios/c2pa_flutter.podspec
@@ -1,24 +1,24 @@
-# Stub podspec for Flutter plugin validation on non-macOS platforms.
-# iOS builds use Swift Package Manager (see ios/c2pa_flutter/Package.swift).
-# This file exists only to satisfy Flutter's plugin validation on Linux CI.
+# This podspec is intentionally minimal. It exists only to satisfy Flutter's
+# plugin validation on platforms where CocoaPods is checked. iOS builds must
+# use Swift Package Manager (see ios/c2pa_flutter/Package.swift).
+#
+# To enable SPM in your Flutter project:
+#   flutter config --enable-swift-package-manager
 
 Pod::Spec.new do |s|
   s.name             = 'c2pa_flutter'
   s.version          = '0.0.1'
-  s.summary          = 'C2PA Flutter plugin - iOS uses Swift Package Manager'
+  s.summary          = 'C2PA Flutter plugin - requires Swift Package Manager'
   s.description      = <<-DESC
 Flutter plugin for C2PA content authenticity. iOS builds require Swift Package Manager.
-This podspec is a stub for CI validation only.
+CocoaPods is not supported. Enable SPM with: flutter config --enable-swift-package-manager
                        DESC
-  s.homepage         = 'https://github.com/user/c2pa_flutter'
+  s.homepage         = 'https://github.com/guardianproject/c2pa-flutter'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }
   s.author           = { 'Guardian Project' => 'support@guardianproject.info' }
   s.source           = { :path => '.' }
-  s.source_files     = 'c2pa_flutter/Sources/c2pa_flutter/**/*.swift'
+  s.source_files     = 'cocoapods_stub/**/*.swift'
   s.platform         = :ios, '16.0'
   s.swift_version    = '5.9'
   s.dependency 'Flutter'
-
-  # This is a stub - actual iOS builds use Swift Package Manager
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/ios/cocoapods_stub/C2paPlugin.swift
+++ b/ios/cocoapods_stub/C2paPlugin.swift
@@ -1,0 +1,12 @@
+#error("""
+c2pa_flutter requires Swift Package Manager. CocoaPods is not supported.
+
+To fix this, enable SPM in your Flutter project:
+
+  flutter config --enable-swift-package-manager
+
+Then clean and rebuild:
+
+  cd ios && rm -rf Pods Podfile.lock && cd ..
+  flutter clean && flutter pub get && flutter build ios
+""")


### PR DESCRIPTION
## Summary
- Removes CocoaPods as a viable build path for iOS. The podspec previously referenced the plugin source files, which caused builds to fail with "Unable to find module dependency: C2PA" because the C2PA module was never declared as a CocoaPods dependency.
- The podspec now points to a stub file that emits a clear compile-time error directing users to enable SPM.
- iOS builds continue to work via Swift Package Manager through ios/c2pa_flutter/Package.swift, which correctly declares the c2pa-ios dependency.

## Changes
- **ios/c2pa_flutter.podspec**: Replaced source_files pointing at real plugin sources with a reference to cocoapods_stub/. Removed pod_target_xcconfig. Fixed homepage URL.
- **ios/cocoapods_stub/C2paPlugin.swift** (new): Swift #error directive that produces a clear message when someone attempts a CocoaPods-based build.

## Test plan
- [x] flutter pub get succeeds in the example app
- [x] flutter build ios --no-codesign succeeds (SPM path)
- [ ] Verify CocoaPods path produces the expected #error message (requires a project without SPM enabled)

Generated with [Claude Code](https://claude.com/claude-code)